### PR TITLE
Use the correct type for sending UID to polkit

### DIFF
--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -193,7 +193,7 @@ impl Subject {
         let mut hashmap = HashMap::new();
         hashmap.insert("pid".to_string(), pid.into());
         hashmap.insert("start-time".to_string(), start_time.into());
-        hashmap.insert("uid".to_string(), uid.into());
+        hashmap.insert("uid".to_string(), (uid as i32).into());
 
         Ok(Self {
             subject_kind: "unix-process".into(),


### PR DESCRIPTION
I recently received a vulnerability report for my software using zbus_polkit for authorization regarding a PID reuse attack, when a malicious process reuses a PID of a process that was previously legitimately granted the permissions.

I've then fixed this by passing a UID acquired from a known-good source (unix socket peer credentials) into `Subject::new_for_owner`.

However, after closer investigation, turns out this actually does not help. `uid` is supposed to be an i32 in Polkit's DBus protocol, but it is currently sent as a u32. This causes Polkit to treat the request as if `uid` was not supplied at all, and do its own `/proc` lookup (which is known to be racy), and makes the mitigation useless.

This is trivially verifiable with this example:
```rust
use zbus::Connection;
use zbus_polkit::policykit1::*;

#[tokio::main(flavor = "current_thread")]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let connection = Connection::system().await?;
    let proxy = AuthorityProxy::new(&connection).await?;

    let subject = Subject::new_for_owner(std::process::id(), None, Some(12345))?;

    let result = proxy
        .check_authorization(
            &subject,
            "org.freedesktop.policykit.exec",
            &std::collections::HashMap::new(),
            CheckAuthorizationFlags::AllowUserInteraction.into(),
            "",
        )
        .await?;

    println!("{result:?}");

    Ok(())
}
```

Before the fix, running this as a normal user gives an authorization prompt (which actually authorizes the current user, not the provided `12345`), while running as root instantly gives an `is_authorized: true`, because the requester is looked up to be root.

After the fix, running as a normal user fails with this error:
```
Only trusted callers (e.g. uid 0 or an action owner) can use CheckAuthorization() for subjects belonging to other identities"
```
Which is expected when trying to authorize as another user as non-root.