### PR TITLE
👷 Bring CI in line with zbus

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,13 +2,19 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "commitMessagePrefix": "⬆️  "
+      "commitMessageAction": "⬆️  Update"
     },
     {
       "matchManagers": ["cargo"],
-      "commitMessagePrefix": "⬆️  ",
+      "commitMessageAction": "⬆️  Update",
       "commitMessageTopic": "{{depName}}",
       "lockFileMaintenance": { "enabled": true }
+    },
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "commitMessageAction": "⬆️  micro: Update",
+      "automerge": true,
+      "rebaseWhen": "conflicted"
     }
   ]
 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: cargo --locked fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Catch common mistakes
-        run: cargo clippy --all
+        run: cargo --locked clippy --all
 
   test:
     runs-on: ubuntu-latest
@@ -50,7 +50,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Test on stable Rust
-        run: cargo test
+        run: cargo --locked test
 
   test_nightly:
     runs-on: ubuntu-latest
@@ -66,4 +66,4 @@ jobs:
           toolchain: nightly
       - uses: Swatinem/rust-cache@v2
       - name: Test on nightly Rust
-        run: cargo test
+        run: cargo --locked test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,23 @@ on:
     branches: [main]
 
 jobs:
+  MSRV:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      MSRV: 1.87.0
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.MSRV }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Check build with MSRV
+        run: |
+          cargo --locked check
+          cargo --locked check --no-default-features --features tokio
+          cargo --locked check --all-features
+
   fmt:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,3 +91,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test on nightly Rust
         run: cargo --locked test --all-features
+
+  doc_build:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check documentation build
+        run: cargo --locked doc --all-features --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,11 +47,14 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Catch common mistakes
-        run: cargo --locked clippy --all
+        run: |
+          cargo --locked clippy --all-targets
+          cargo --locked clippy --all-targets --no-default-features --features tokio
+          cargo --locked clippy --all-targets --all-features
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,4 @@
-# Run `cargo test` on windwos, linux and mac
-name: CI
+name: Lint, Build and Test
 
 on:
   push:
@@ -8,46 +7,15 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    env:
-      RUST_LOG: "trace"
-      RUST_BACKTRACE: "full"
-      RUSTFLAGS: -D warnings
-    runs-on: ubuntu-latest
-    needs: [fmt, clippy]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests on stable Rust
-        run: cargo test
-
-  test_nightly:
-    env:
-      RUST_LOG: "trace"
-      RUST_BACKTRACE: "full"
-      RUSTFLAGS: -D warnings
-    runs-on: ubuntu-latest
-    needs: [fmt, clippy]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests on nightly Rust
-        run: cargo test
-
   fmt:
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
+          # We use some nightly fmt options.
           toolchain: nightly
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -55,9 +23,9 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
@@ -65,5 +33,37 @@ jobs:
           toolchain: nightly
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Check common mistakes
+      - name: Catch common mistakes
         run: cargo clippy --all
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: full
+      RUST_LOG: trace
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Test on stable Rust
+        run: cargo test
+
+  test_nightly:
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: full
+      RUST_LOG: trace
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@v2
+      - name: Test on nightly Rust
+        run: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,3 +104,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Check documentation build
         run: cargo --locked doc --all-features --no-deps
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,8 +69,12 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
-      - name: Test on stable Rust
+      - name: Test default features (async-io + blocking-api)
         run: cargo --locked test
+      - name: Test tokio without blocking-api
+        run: cargo --locked test --no-default-features --features tokio
+      - name: Test all features (async-io + tokio + blocking-api)
+        run: cargo --locked test --all-features
 
   test_nightly:
     runs-on: ubuntu-latest
@@ -86,4 +90,4 @@ jobs:
           toolchain: nightly
       - uses: Swatinem/rust-cache@v2
       - name: Test on nightly Rust
-        run: cargo --locked test
+        run: cargo --locked test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Zeeshan Ali Khan <zeenix@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.87"
 
 description = "PolicyKit binding"
 repository = "https://github.com/z-galaxy/zbus_polkit/"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zbus_polkit
 
-[![CI Pipeline Status](https://github.com/z-galaxy/zbus/actions/workflows/rust.yml/badge.svg)](https://github.com/z-galaxy/zbus/actions/workflows/rust.yml)
+[![CI Pipeline Status](https://github.com/z-galaxy/zbus_polkit/actions/workflows/rust.yml/badge.svg)](https://github.com/z-galaxy/zbus_polkit/actions/workflows/rust.yml)
 [![Documentation](https://docs.rs/zbus_polkit/badge.svg)](https://docs.rs/zbus_polkit/)
 [![crates.io](https://img.shields.io/crates/v/zbus_polkit)](https://crates.io/crates/zbus_polkit)
 


### PR DESCRIPTION
Follow-up to #102, syncing the remaining CI infra with zbus:

- `--locked` on every cargo invocation
- MSRV job. Requires 1.87 now
- `clippy` on `stable` instead of `nightly`
- test default, tokio-only, and all-features
- doc build with `RUSTDOCFLAGS=-D warnings`
- `cargo-semver-checks` on PRs
- renovate config synced

Also fixes the README CI badge, which pointed at the zbus repo.
