### PR TITLE
🔧 Add repository hygiene files from zbus

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+ignore-words-list = crate,ser
+skip = ./.git/**,./target/**,./Cargo.lock

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.rs]
+max_line_length = 100
+
+[*.md]
+max_line_length = 100

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+<!--
+
+Thank you for your contribution! 🙏
+
+We hope you have read our contribution guideline and followed it to the best of your abilities:
+
+https://github.com/z-galaxy/zbus_polkit/blob/main/CONTRIBUTING.md#submitting-pull-requests
+
+-->

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+imports_granularity = "Crate"
+comment_width = 100
+wrap_comments = true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+We take security seriously and provide security updates for the latest version of zbus_polkit. We
+strongly recommend keeping your zbus_polkit dependency up to date.
+
+## Reporting a Vulnerability
+
+If you believe or suspect there is a vulnerability, please report it privately via the "Report a
+vulnerability" button in the "Security" tab of the repository.
+
+See the [GitHub documentation on privately reporting a security vulnerability][gh-report] for
+details.
+
+[gh-report]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability

--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -411,8 +411,9 @@ pub trait Authority {
     ) -> zbus::Result<()>;
 
     /// Like `RegisterAuthenticationAgent` but takes additional options. If the option fallback (of
-    /// type Boolean) is TRUE, then the authentcation agent will only be used as a fallback, e.g. if
-    /// another agent (without the fallback option set TRUE) is available, it will be used instead.
+    /// type Boolean) is TRUE, then the authentication agent will only be used as a fallback, e.g.
+    /// if another agent (without the fallback option set TRUE) is available, it will be used
+    /// instead.
     fn register_authentication_agent_with_options(
         &self,
         subject: &Subject,


### PR DESCRIPTION
Copying the remaining boilerplate from zbus:

- `.rustfmt.toml`
- `.editorconfig`
- `.codespellrc`, (includes a typo found in docs)
- `SECURITY.md` pointing at GitHub private vulnerability reporting
- PR template linking to this repo's CONTRIBUTING.md

I didn't include `.githooks/` since CONTRIBUTING.md recommends the gimoji hook instead. Lmk if that should be changed though