### PR TITLE
🔧 Add git hook scripts from zbus

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+GITHOOKS_DIR=$( cd -- "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
+source $GITHOOKS_DIR/util.sh
+
+ensure_rustup_installed
+ensure_rustfmt_installed
+
+check_formatting

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/bash
+GITHOOKS_DIR=$( cd -- "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
+source $GITHOOKS_DIR/util.sh
+
+ensure_rustup_installed
+ensure_clippy_installed
+
+check_clippy

--- a/.githooks/util.sh
+++ b/.githooks/util.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Utility functions for git hook scripts.
+
+if test -t 1 && test -n "$(tput colors)" && test "$(tput colors)" -ge 8; then
+    bold="$(tput bold)"
+    normal="$(tput sgr0)"
+    green="$(tput setaf 2)"
+    red="$(tput setaf 1)"
+    blue="$(tput setaf 4)"
+
+    function hook_failure {
+        echo "${red}${bold}FAILED:${normal} ${1}${normal}"
+        exit 1
+    }
+
+    function hook_info {
+        echo "${blue}${1}${normal}"
+    }
+
+    function hook_success {
+        echo "${green}${bold}SUCCESS:${normal} ${1}${normal}"
+        echo
+        echo
+    }
+
+else
+    function hook_failure {
+        echo "FAILED: ${1}"
+        exit 1
+    }
+
+    function hook_info {
+        echo "${1}"
+    }
+
+    function hook_success {
+        echo "SUCCESS: ${1}"
+        echo
+        echo
+    }
+fi
+
+function ensure_rustup_installed() {
+    hook_info "📦️ Ensuring that rustup is installed"
+    if ! which rustup &> /dev/null; then
+        curl https://sh.rustup.rs -sSf  | sh -s -- -y
+        export PATH=$PATH:$HOME/.cargo/bin
+        if ! which rustup &> /dev/null; then
+            hook_failure "Failed to install rustup"
+        else
+            hook_success "rustup installed."
+        fi
+    else
+        hook_success "rustup is already installed."
+    fi
+}
+
+function ensure_rustfmt_installed() {
+    hook_info "📦️ Ensuring that nightly rustfmt is installed"
+    if ! rustup component list --toolchain nightly|grep 'rustfmt-preview.*(installed)' &> /dev/null; then
+        rustup component add rustfmt-preview --toolchain nightly
+        hook_success "rustfmt installed."
+    else
+        hook_success "rustfmt is already installed."
+    fi
+}
+
+function ensure_clippy_installed() {
+    hook_info "📦️ Ensuring that clippy is installed"
+    if ! rustup component list --toolchain stable|grep 'clippy.*(installed)' &> /dev/null; then
+        rustup component add clippy
+        hook_success "clippy installed."
+    else
+        hook_success "clippy is already installed."
+    fi
+}
+
+function check_formatting() {
+    hook_info "🎨 Running 'cargo +nightly fmt -- --check'"
+    cargo +nightly fmt -- --check \
+        && hook_success "Project is formatted" \
+        || hook_failure "Cargo format detected errors."
+}
+
+function check_clippy() {
+    hook_info "🔍 Running 'cargo clippy -- -D warnings'"
+    cargo clippy -- -D warnings \
+        && hook_success "Clippy detected no issues" \
+        || hook_failure "Cargo clippy detected errors."
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,16 @@ cases, it's acceptable to tell clippy to [ignore the specific error or warning i
 code][clippy-allow].
 
 If you intend to contribute often or think that's very likely, we recommend installing the commit
-hook provided by [`gimoji`][gimoji].
+hook provided by [`gimoji`][gimoji], as well as the git hook scripts contained within this
+repository, which run `rustfmt` before each commit and `clippy` before each push. You can enable
+them with:
+
+```sh
+cp .githooks/* .git/hooks/
+```
+
+The two do not conflict: `gimoji` installs a `prepare-commit-msg` hook, while the scripts here are
+`pre-commit` and `pre-push` hooks.
 
 ## Conduct
 


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus_polkit/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
As suggested in #105: the pre-commit (rustfmt) and pre-push (clippy) hook scripts from zbus, plus a CONTRIBUTING.md paragraph recommending them alongside the gimoji prepare-commit-msg hook.

The changes in this PR were created using Fable 5.1 via Cursor entirely, and then manually reviewed by me afterwards. No changes were made after Fable's implementation. 