### PR TITLE
✅ Add unit tests

### DIFF
--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -474,6 +474,8 @@ assert_impl_all!(AuthorityProxyBlocking<'_>: Send, Sync, Unpin);
 
 #[cfg(test)]
 mod tests {
+    use zbus::zvariant::{serialized::Context, to_bytes, LE};
+
     use super::*;
 
     #[test]
@@ -582,5 +584,51 @@ mod tests {
             parse_uid("Uid:\tnobody\n"),
             Err(Error::ParseInt(_))
         ));
+    }
+
+    // Signatures as documented in the polkit D-Bus API reference:
+    // https://polkit.pages.freedesktop.org/polkit/eggdbus-interface-org.freedesktop.PolicyKit1.Authority.html
+    #[test]
+    fn wire_signatures_match_polkit() {
+        assert_eq!(Subject::SIGNATURE.to_string(), "(sa{sv})");
+        assert_eq!(<Identity<'_>>::SIGNATURE.to_string(), "(sa{sv})");
+        assert_eq!(
+            TemporaryAuthorization::SIGNATURE.to_string(),
+            "(ss(sa{sv})tt)"
+        );
+        assert_eq!(ActionDescription::SIGNATURE.to_string(), "(ssssssuuua{ss})");
+        assert_eq!(AuthorizationResult::SIGNATURE.to_string(), "(bba{ss})");
+
+        assert_eq!(CheckAuthorizationFlags::SIGNATURE.to_string(), "u");
+        assert_eq!(
+            BitFlags::<CheckAuthorizationFlags>::SIGNATURE.to_string(),
+            "u"
+        );
+        assert_eq!(ImplicitAuthorization::SIGNATURE.to_string(), "u");
+        assert_eq!(AuthorityFeatures::SIGNATURE.to_string(), "u");
+    }
+
+    #[test]
+    fn enums_serialize_as_their_u32_discriminant() {
+        let ctxt = Context::new_dbus(LE, 0);
+
+        let encoded = to_bytes(ctxt, &ImplicitAuthorization::Authorized).unwrap();
+        assert_eq!(encoded.bytes(), 5u32.to_le_bytes());
+        let (decoded, _) = encoded.deserialize::<ImplicitAuthorization>().unwrap();
+        assert_eq!(decoded, ImplicitAuthorization::Authorized);
+
+        let flags: BitFlags<CheckAuthorizationFlags> =
+            CheckAuthorizationFlags::AllowUserInteraction.into();
+        let encoded = to_bytes(ctxt, &flags).unwrap();
+        assert_eq!(encoded.bytes(), 1u32.to_le_bytes());
+    }
+
+    #[test]
+    fn authority_features_from_value() {
+        let features = AuthorityFeatures::try_from(OwnedValue::from(1u32)).unwrap();
+        assert_eq!(features, AuthorityFeatures::TemporaryAuthorization);
+
+        let not_a_u32 = OwnedValue::try_from(Value::Str("nope".into())).unwrap();
+        assert!(AuthorityFeatures::try_from(not_a_u32).is_err());
     }
 }

--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -474,7 +474,10 @@ assert_impl_all!(AuthorityProxyBlocking<'_>: Send, Sync, Unpin);
 
 #[cfg(test)]
 mod tests {
-    use zbus::zvariant::{serialized::Context, to_bytes, LE};
+    use zbus::{
+        message::Message,
+        zvariant::{serialized::Context, to_bytes, LE},
+    };
 
     use super::*;
 
@@ -630,5 +633,32 @@ mod tests {
 
         let not_a_u32 = OwnedValue::try_from(Value::Str("nope".into())).unwrap();
         assert!(AuthorityFeatures::try_from(not_a_u32).is_err());
+    }
+
+    #[test]
+    fn subject_for_message_header_uses_the_sender_bus_name() {
+        let msg = Message::method_call("/org/example/Object", "Frobnicate")
+            .unwrap()
+            .sender(":1.42")
+            .unwrap()
+            .build(&())
+            .unwrap();
+
+        let subject = Subject::new_for_message_header(&msg.header()).unwrap();
+
+        assert_eq!(subject.subject_kind, "system-bus-name");
+        assert_eq!(subject.subject_details.len(), 1);
+        assert_eq!(*subject.subject_details["name"], Value::Str(":1.42".into()));
+    }
+
+    #[test]
+    fn subject_for_message_header_requires_a_sender() {
+        let msg = Message::method_call("/org/example/Object", "Frobnicate")
+            .unwrap()
+            .build(&())
+            .unwrap();
+
+        let err = Subject::new_for_message_header(&msg.header()).unwrap_err();
+        assert!(matches!(err, Error::MissingSender), "{err:?}");
     }
 }

--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::BufRead};
+use std::collections::HashMap;
 
 use enumflags2::{bitflags, BitFlags};
 use serde::{Deserialize, Serialize};
@@ -110,37 +110,6 @@ pub struct Identity<'a> {
 
 assert_impl_all!(Identity<'_>: Send, Sync, Unpin);
 
-fn pid_start_time(pid: u32) -> Result<u64, Error> {
-    let fname = format!("/proc/{pid}/stat");
-    let content = std::fs::read_to_string(fname)?;
-
-    if let Some(i) = content.rfind(')') {
-        if let Some(start_time) = content[i..].split(' ').nth(20) {
-            return Ok(start_time.parse()?);
-        }
-    }
-
-    Err(std::io::Error::from(std::io::ErrorKind::NotFound).into())
-}
-
-// Return the "current" UID.  Note that this is inherently racy, and the value may already be
-// obsolete by the time this function returns; this function only guarantees that the UID was valid
-// at some point during its execution.
-fn pid_uid_racy(pid: u32) -> Result<u32, Error> {
-    let fname = format!("/proc/{pid}/status");
-    let file = std::fs::File::open(fname)?;
-    let lines = std::io::BufReader::new(file).lines();
-    for line in lines.map_while(Result::ok) {
-        if line.starts_with("Uid:") {
-            if let Some(uid) = line.split('\t').nth(1) {
-                return Ok(uid.parse()?);
-            }
-        }
-    }
-
-    Err(std::io::Error::from(std::io::ErrorKind::NotFound).into())
-}
-
 /// This struct describes subjects such as UNIX processes. It is typically used to check if a given
 /// process is authorized for an action.
 ///
@@ -229,6 +198,47 @@ impl Subject {
             subject_details,
         })
     }
+}
+
+fn pid_start_time(pid: u32) -> Result<u64, Error> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat"))?;
+    parse_start_time(&stat)
+}
+
+// Extract the process start time (field 22 of proc(5) `stat`, in clock ticks since boot).
+//
+// The second field, `comm`, is the executable name wrapped in parentheses and may itself contain
+// spaces and parentheses, so fields are counted from the *last* closing parenthesis rather than
+// from the start of the line.
+fn parse_start_time(stat: &str) -> Result<u64, Error> {
+    let start_time = stat
+        .rfind(')')
+        .and_then(|i| stat[i..].split(' ').nth(20))
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotFound))?;
+
+    Ok(start_time.parse()?)
+}
+
+// Return the "current" UID.  Note that this is inherently racy, and the value may already be
+// obsolete by the time this function returns; this function only guarantees that the UID was valid
+// at some point during its execution.
+fn pid_uid_racy(pid: u32) -> Result<u32, Error> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status"))?;
+    parse_uid(&status)
+}
+
+// Extract the real UID from the contents of proc(5) `status`.
+//
+// The `Uid:` line lists the real, effective, saved set and filesystem UIDs; only the first one is
+// returned, since that is what polkit expects in a `unix-process` subject.
+fn parse_uid(status: &str) -> Result<u32, Error> {
+    let uid = status
+        .lines()
+        .find_map(|line| line.strip_prefix("Uid:"))
+        .and_then(|uids| uids.split_whitespace().next())
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotFound))?;
+
+    Ok(uid.parse()?)
 }
 
 /// This struct describes actions registered with the PolicyKit daemon.

--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -471,3 +471,116 @@ pub trait Authority {
 assert_impl_all!(AuthorityProxy<'_>: Send, Sync, Unpin);
 #[cfg(feature = "blocking-api")]
 assert_impl_all!(AuthorityProxyBlocking<'_>: Send, Sync, Unpin);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subject_for_owner_uses_polkit_wire_types() {
+        let subject = Subject::new_for_owner(4242, Some(1_000_000), Some(1234)).unwrap();
+
+        assert_eq!(subject.subject_kind, "unix-process");
+        assert_eq!(subject.subject_details.len(), 3);
+        assert_eq!(*subject.subject_details["pid"], Value::U32(4242));
+        assert_eq!(
+            *subject.subject_details["start-time"],
+            Value::U64(1_000_000)
+        );
+        // polkit reads `uid` as a signed 32-bit integer. Sent as any other type it is silently
+        // ignored and polkit falls back to its own racy /proc lookup, which defeats the purpose
+        // of passing a UID obtained from a trusted source (see #101).
+        assert_eq!(*subject.subject_details["uid"], Value::I32(1234));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn subject_for_owner_looks_up_the_process_in_proc() {
+        use std::os::unix::fs::MetadataExt;
+
+        let pid = std::process::id();
+        let subject = Subject::new_for_owner(pid, None, None).unwrap();
+
+        // /proc/<pid> is owned by the process's UID, which gives us an independent source of
+        // truth that doesn't go through the parser under test.
+        let uid = std::fs::metadata("/proc/self").unwrap().uid();
+        let stat = std::fs::read_to_string("/proc/self/stat").unwrap();
+        let start_time = parse_start_time(&stat).unwrap();
+
+        assert_eq!(*subject.subject_details["pid"], Value::U32(pid));
+        assert_eq!(*subject.subject_details["uid"], Value::I32(uid as i32));
+        assert_eq!(
+            *subject.subject_details["start-time"],
+            Value::U64(start_time)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn subject_for_owner_fails_for_a_missing_process() {
+        // pid_max is capped at 2^22 on Linux, so this PID can never exist.
+        let err = Subject::new_for_owner(u32::MAX, None, None).unwrap_err();
+        assert!(matches!(err, Error::Io(_)), "{err:?}");
+    }
+
+    #[test]
+    fn start_time_is_field_22_counted_from_the_last_paren() {
+        // proc(5): pid, (comm), state, ppid, pgrp, session, tty_nr, tpgid, flags, minflt,
+        // cminflt, majflt, cmajflt, utime, stime, cutime, cstime, priority, nice, num_threads,
+        // itrealvalue, starttime, vsize, rss, ...
+        let stat = "1 (systemd) S 0 1 1 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 1 0 42 12345678 100\n";
+        assert_eq!(parse_start_time(stat).unwrap(), 42);
+
+        // `comm` is not escaped, so a process name containing spaces and parentheses shifts
+        // every naive field count. Counting from the last `)` is what makes this work.
+        let stat = "1234 (my (weird) proc) S 1 1234 1234 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 1 \
+                    0 987654 12345678 100\n";
+        assert_eq!(parse_start_time(stat).unwrap(), 987654);
+    }
+
+    #[test]
+    fn start_time_rejects_malformed_stat() {
+        assert!(matches!(parse_start_time(""), Err(Error::Io(_))));
+        assert!(matches!(
+            parse_start_time("no parens here"),
+            Err(Error::Io(_))
+        ));
+        // Too few fields after `comm`.
+        assert!(matches!(
+            parse_start_time("1234 (x) S 1 1234"),
+            Err(Error::Io(_))
+        ));
+        // Field 22 present but not a number.
+        let stat = "1 (x) S 0 1 1 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 1 0 forty-two 12345678 100";
+        assert!(matches!(parse_start_time(stat), Err(Error::ParseInt(_))));
+    }
+
+    #[test]
+    fn uid_is_the_real_uid_from_status() {
+        let status = "Name:\tmy proc\n\
+                      Umask:\t0022\n\
+                      State:\tS (sleeping)\n\
+                      Tgid:\t1234\n\
+                      Pid:\t1234\n\
+                      PPid:\t1\n\
+                      TracerPid:\t0\n\
+                      Uid:\t1000\t1001\t1002\t1003\n\
+                      Gid:\t2000\t2001\t2002\t2003\n";
+        // Real UID, not effective (1001) or saved-set (1002).
+        assert_eq!(parse_uid(status).unwrap(), 1000);
+    }
+
+    #[test]
+    fn uid_rejects_malformed_status() {
+        assert!(matches!(parse_uid(""), Err(Error::Io(_))));
+        assert!(matches!(
+            parse_uid("Name:\tx\nGid:\t0\t0\t0\t0\n"),
+            Err(Error::Io(_))
+        ));
+        assert!(matches!(parse_uid("Uid:\n"), Err(Error::Io(_))));
+        assert!(matches!(
+            parse_uid("Uid:\tnobody\n"),
+            Err(Error::ParseInt(_))
+        ));
+    }
+}


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus_polkit/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
This first slice of tests covers everything that doesn't need a polkit daemon. A mock Authority over a p2p connection will follow in a separate PR.

- split `/proc` parsing out of the file reads so it's testable with fixtures (this was mainly mechanical)
- wire signatures and bytes for every type, the regression for uid types found in #101, live `/proc` lookup cross-checked against `/proc/self` ownership, the "comm with spaces and parens" case in stat parsing, real-vs-effective uid, malformed input, and message-header subjects with/without a sender